### PR TITLE
when running frontend against a remote coordinator, http -> https are…

### DIFF
--- a/frontend/.env.dist
+++ b/frontend/.env.dist
@@ -1,4 +1,5 @@
 #in development or if you want to build this on your own: provide a coordinator endpoint
 #in a docker scenario docker-compose takes care of this.
 SKIP_PREFLIGHT_CHECK=true
-REACT_APP_COORDINATOR=coordinator.{default}:{PORT}
+REACT_APP_COORDINATOR=https://coordinator.on_your.eu-2.platformsh.site
+

--- a/frontend/src/coordinator.js
+++ b/frontend/src/coordinator.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 export const endpoint = process.env.REACT_APP_COORDINATOR ?
-    "//" + process.env.REACT_APP_COORDINATOR :
+    process.env.REACT_APP_COORDINATOR :
     "//coordinator." + window.location.host
 
 export const coordinator = axios.get(endpoint)


### PR DESCRIPTION
… killing your frontend xhr. this helps it

Signed-off-by: Stefan Adolf <stefan.adolf@turbinekreuzberg.com>